### PR TITLE
Add DataCubeTexture support

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -1,9 +1,10 @@
 import {
 	CompressedArrayTexture,
 	CompressedCubeTexture,
-	CompressedTexture,
-	Data3DTexture,
-	DataTexture,
+       CompressedTexture,
+       Data3DTexture,
+       DataCubeTexture,
+       DataTexture,
 	FileLoader,
 	FloatType,
 	HalfFloatType,
@@ -1090,13 +1091,38 @@ async function createRawTexture( container ) {
 
 	let texture;
 
-	if ( UNCOMPRESSED_FORMATS.has( FORMAT_MAP[ vkFormat ] ) ) {
+       if ( UNCOMPRESSED_FORMATS.has( FORMAT_MAP[ vkFormat ] ) ) {
 
-		texture = container.pixelDepth === 0
-			? new DataTexture( mipmaps[ 0 ].data, container.pixelWidth, container.pixelHeight )
-			: new Data3DTexture( mipmaps[ 0 ].data, container.pixelWidth, container.pixelHeight, container.pixelDepth );
+               if ( container.faceCount === 6 ) {
 
-	} else {
+                       const faceSize = mipmaps[ 0 ].data.byteLength / 6;
+                       const faces = [];
+
+                       for ( let i = 0; i < 6; i ++ ) {
+
+                               const offset = i * faceSize;
+                               const data = new mipmaps[ 0 ].data.constructor(
+                                       mipmaps[ 0 ].data.buffer,
+                                       mipmaps[ 0 ].data.byteOffset + offset,
+                                       faceSize / mipmaps[ 0 ].data.BYTES_PER_ELEMENT
+                               );
+
+                               faces.push( { data, width: container.pixelWidth, height: container.pixelHeight } );
+
+                       }
+
+                       texture = new DataCubeTexture();
+                       texture.image = faces;
+
+               } else {
+
+                       texture = container.pixelDepth === 0
+                               ? new DataTexture( mipmaps[ 0 ].data, container.pixelWidth, container.pixelHeight )
+                               : new Data3DTexture( mipmaps[ 0 ].data, container.pixelWidth, container.pixelHeight, container.pixelDepth );
+
+               }
+
+       } else {
 
 		if ( container.pixelDepth > 0 ) throw new Error( 'THREE.KTX2Loader: Unsupported pixelDepth.' );
 

--- a/src/Three.Core.js
+++ b/src/Three.Core.js
@@ -28,6 +28,7 @@ export { Source } from './textures/Source.js';
 export { DataTexture } from './textures/DataTexture.js';
 export { DataArrayTexture } from './textures/DataArrayTexture.js';
 export { Data3DTexture } from './textures/Data3DTexture.js';
+export { DataCubeTexture } from './textures/DataCubeTexture.js';
 export { CompressedTexture } from './textures/CompressedTexture.js';
 export { CompressedArrayTexture } from './textures/CompressedArrayTexture.js';
 export { CompressedCubeTexture } from './textures/CompressedCubeTexture.js';

--- a/src/textures/DataCubeTexture.js
+++ b/src/textures/DataCubeTexture.js
@@ -1,0 +1,125 @@
+import { Texture } from './Texture.js';
+import { CubeReflectionMapping, NearestFilter } from '../constants.js';
+
+/**
+ * Creates a cube data texture from six faces of typed array data.
+ *
+ * @augments Texture
+ */
+class DataCubeTexture extends Texture {
+
+    /**
+     * Constructs a new data cube texture.
+     *
+     * @param {Array<TypedArray>} [data=[]] - Array of six typed arrays.
+     * @param {number} [width=1] - Width of each face.
+     * @param {number} [height=1] - Height of each face.
+     */
+    constructor( data = [], width = 1, height = 1 ) {
+
+        super( null, CubeReflectionMapping );
+
+        /**
+         * This flag can be used for type testing.
+         *
+         * @type {boolean}
+         * @readonly
+         * @default true
+         */
+        this.isDataCubeTexture = true;
+
+        /**
+         * This flag can be used for type testing.
+         *
+         * @type {boolean}
+         * @readonly
+         * @default true
+         */
+        this.isCubeTexture = true;
+
+        // Ensure six faces exist
+        const faces = new Array( 6 ).fill( null ).map( ( _, i ) => {
+            const faceData = data[ i ] || null;
+            return { data: faceData, width, height };
+        } );
+
+        /**
+         * Array of cube faces.
+         *
+         * @type {Array<{data:TypedArray,width:number,height:number}>}
+         */
+        this.image = faces;
+
+        /**
+         * How the texture is sampled when a texel covers more than one pixel.
+         *
+         * Overwritten and set to `NearestFilter` by default.
+         *
+         * @type {(NearestFilter|NearestMipmapNearestFilter|NearestMipmapLinearFilter|LinearFilter|LinearMipmapNearestFilter|LinearMipmapLinearFilter)}
+         * @default NearestFilter
+         */
+        this.magFilter = NearestFilter;
+
+        /**
+         * How the texture is sampled when a texel covers less than one pixel.
+         *
+         * Overwritten and set to `NearestFilter` by default.
+         *
+         * @type {(NearestFilter|NearestMipmapNearestFilter|NearestMipmapLinearFilter|LinearFilter|LinearMipmapNearestFilter|LinearMipmapLinearFilter)}
+         * @default NearestFilter
+         */
+        this.minFilter = NearestFilter;
+
+        /**
+         * Whether to generate mipmaps (if possible) for a texture.
+         *
+         * Overwritten and set to `false` by default.
+         *
+         * @type {boolean}
+         * @default false
+         */
+        this.generateMipmaps = false;
+
+        /**
+         * If set to `true`, the texture is flipped along the vertical axis when
+         * uploaded to the GPU.
+         *
+         * Overwritten and set to `false` by default.
+         *
+         * @type {boolean}
+         * @default false
+         */
+        this.flipY = false;
+
+        /**
+         * Specifies the alignment requirements for the start of each pixel row in memory.
+         *
+         * Overwritten and set to `1` by default.
+         *
+         * @type {number}
+         * @default 1
+         */
+        this.unpackAlignment = 1;
+
+    }
+
+    /**
+     * Alias for {@link DataCubeTexture#image}.
+     *
+     * @type {Array<{data:TypedArray,width:number,height:number}>}
+     */
+    get faces() {
+
+        return this.image;
+
+    }
+
+    set faces( value ) {
+
+        this.image = value;
+
+    }
+
+}
+
+export { DataCubeTexture };


### PR DESCRIPTION
## Summary
- add `DataCubeTexture` class storing explicit face data
- export new class via `Three.Core.js`
- update `KTX2Loader` to populate `DataCubeTexture` when loading raw cubemaps

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686204ff90dc8323b3dcb1718a95c0f3