### PR TITLE
Add DataCubeTexture docs and extend KTX2 loader info

### DIFF
--- a/docs/api/en/textures/DataCubeTexture.html
+++ b/docs/api/en/textures/DataCubeTexture.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:Texture] &rarr;
+
+               <h1>[name]</h1>
+
+               <p class="desc">
+                       Creates a cube texture directly from raw data. The data array
+                       contains texel information for all six faces in the order
+                       <code>+x</code>, <code>-x</code>, <code>+y</code>, <code>-y</code>,
+                       <code>+z</code>, <code>-z</code>.
+               </p>
+
+		<h2>Constructor</h2>
+
+               <h3>
+                       [name]( data, width, height, format, type, mapping, wrapS, wrapT,
+                       magFilter, minFilter, anisotropy, colorSpace )
+               </h3>
+               <p>
+                       The data argument must be an
+                       [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
+                       The array length should be <code>width * height * 6 * n</code>,
+                       where <code>n</code> is the number of color channels.
+                       Further parameters correspond to the properties
+                       inherited from [page:Texture], where both magFilter and minFilter default
+                       to THREE.NearestFilter.
+		</p>
+		<p>
+			The interpretation of the data depends on type and format: If the type is
+			THREE.UnsignedByteType, a Uint8Array will be useful for addressing the
+			texel data. If the format is THREE.RGBAFormat, data needs four values for
+			one texel; Red, Green, Blue and Alpha (typically the opacity).<br />
+
+			For the packed types, THREE.UnsignedShort4444Type and
+			THREE.UnsignedShort5551Type all color components of one texel can be
+			addressed as bitfields within an integer element of a Uint16Array.<br />
+
+			In order to use the types THREE.FloatType and THREE.HalfFloatType, the
+			WebGL implementation must support the respective extensions
+			OES_texture_float and OES_texture_half_float. In order to use
+			THREE.LinearFilter for component-wise, bilinear interpolation of the
+			texels based on these types, the WebGL extensions OES_texture_float_linear
+			or OES_texture_half_float_linear must also be present.
+		</p>
+
+		<h2>Code Example</h2>
+
+               <code>
+               // create a buffer with color data for six faces
+               const width = 256;
+               const height = 256;
+
+               const size = width * height;
+               const data = new Uint8Array( 4 * size * 6 );
+
+               for ( let i = 0; i < 6 * size; i ++ ) {
+                       const stride = i * 4;
+                       data[ stride ] = 255; // R
+                       data[ stride + 1 ] = 0; // G
+                       data[ stride + 2 ] = 0; // B
+                       data[ stride + 3 ] = 255; // A
+               }
+
+               // use the buffer to create a [name]
+               const texture = new THREE.DataCubeTexture( data, width, height );
+               texture.needsUpdate = true;
+               </code>
+
+		<h2>Properties</h2>
+
+		<p>See the base [page:Texture Texture] class for common properties.</p>
+
+		<h3>[property:Boolean flipY]</h3>
+		<p>
+			If set to `true`, the texture is flipped along the vertical axis when
+			uploaded to the GPU. Default is `false`.
+		</p>
+
+		<h3>[property:Boolean generateMipmaps]</h3>
+		<p>
+			Whether to generate mipmaps (if possible) for a texture. False by default.
+		</p>
+
+               <h3>[property:Object image]</h3>
+               <p>Overridden with an object holding data, width, and height.</p>
+
+               <h3>[property:Boolean isDataCubeTexture]</h3>
+               <p>Read-only flag to check if a given object is of type [name].</p>
+
+		<h3>[property:number unpackAlignment]</h3>
+		<p>
+			`1` by default. Specifies the alignment requirements for the start of each
+			pixel row in memory. The allowable values are 1 (byte-alignment), 2 (rows
+			aligned to even-numbered bytes), 4 (word-alignment), and 8 (rows start on
+			double-word boundaries). See
+			[link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei] for more information.
+		</p>
+
+		<h2>Methods</h2>
+
+		<p>See the base [page:Texture Texture] class for common methods.</p>
+
+		<h2>Source</h2>
+
+               <p>
+                       [link:https://github.com/mrdoob/three.js/blob/master/src/textures/DataCubeTexture.js src/textures/DataCubeTexture.js]
+               </p>
+	</body>
+</html>

--- a/docs/api/it/textures/DataCubeTexture.html
+++ b/docs/api/it/textures/DataCubeTexture.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="it">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:Texture] &rarr;
+
+               <h1>[name]</h1>
+
+               <p class="desc">Crea una cube texture direttamente da dati grezzi. L'array dei dati deve contenere le informazioni delle sei facce nell'ordine <code>+x</code>, <code>-x</code>, <code>+y</code>, <code>-y</code>, <code>+z</code>, <code>-z</code>.</p>
+
+		<h2>Costruttore</h2>
+
+		<h3>[name]( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy, colorSpace )</h3>
+		<p>
+                        L'argomento data deve essere un [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView].
+                        La lunghezza dell'array deve essere <code>width * height * 6 * n</code>, dove <code>n</code> è il numero di canali.
+                        Ulteriori parametri corrispondono alle proprietà ereditate da [page:Texture], dove sia magFilter che minFilter per impostazione predefinita sono THREE.NearestFilter.
+		</p>
+		<p>
+			L'interpretazione dei dati dipende dal tipo e dal formato:
+			Se il tipo è THREE.UnsignedByteType, un Uint8Array sarà utile per indirizzare i dati texel.
+			Se il formato è THREE.RGBAFormat, i dati necessitano di quattro valori per un texel; Rosso, Verde, Blu e Alfa (tipicamente l'opacità).<br />
+
+			Per i tipi compressi, THREE.UnsignedShort4444Type e THREE.UnsignedShort5551Type tutti i componenti di colore di un texel possono essere 
+			indirizzati come campi di bit all'interno di un elemento intero di un Uint16Array.<br />
+
+			Per utilizzare i tipi THREE.FloatType e THREE.HalfFloatType, l'implementazione WebGL deve supportare le 
+			rispettive estensioni OES_texture_float e OES_texture_half_float. 
+			Per utilizzare THREE.LinearFilter per l'interpolazione bilineare component-wise dei texel basati
+			su questi tipi, devono essere presenti anche le estensioni WebGL OES_texture_float_linear o OES_texture_half_float_linear.
+		</p>
+
+		<h2>Codice di Esempio</h2>
+
+		<code>
+                // crea un buffer con i dati del colore per le sei facce
+
+                const width = 256;
+                const height = 256;
+
+                const size = width * height;
+                const data = new Uint8Array( 4 * size * 6 );
+
+                for ( let i = 0; i < 6 * size; i ++ ) {
+
+                        const stride = i * 4;
+
+                        data[ stride ] = 255; // R
+                        data[ stride + 1 ] = 0;   // G
+                        data[ stride + 2 ] = 0;   // B
+                        data[ stride + 3 ] = 255; // A
+
+                }
+
+                // utilizza il buffer per creare un [name]
+
+                const texture = new THREE.DataCubeTexture( data, width, height );
+                texture.needsUpdate = true;
+		</code>
+
+		<h2>Proprietà</h2>
+
+		<p>
+    	Vedi la classe base [page:Texture Texture] per le proprietà comuni.
+    </p>
+
+		<h3>[property:Boolean flipY]</h3>
+		<p>
+		Se impostato a `true`, la texture viene capovolta lungo l'asse verticale quando viene caricata sulla GPU. L'impostazione predefinita è `false`.
+		</p>
+
+		<h3>[property:Boolean generateMipmaps]</h3>
+		<p>
+			Indica se generare mipmap (se possibile) per una texture. Falso per impostazione predefinita.
+		</p>
+
+		<h3>[property:Object image]</h3>
+		<p>
+			Sostituito con un tipo di record contenente dati, larghezza, altezza e profondità.
+		</p>
+
+               <h3>[property:Boolean isDataCubeTexture]</h3>
+               <p>
+                       Flag di sola lettura per verificare se l'oggetto dato è di tipo [name].
+               </p>
+
+		<h3>[property:number unpackAlignment]</h3>
+		<p>
+		1 per impostazione predefinita. Specifica i requisiti di allineamento per l'inizio di ogni riga di pixel in memoria.
+		I valori consentiti sono 1 (allineamento byte), 2 (righe allineate a byte pari), 4 (allineamento delle parole) e 8
+		(le righe iniziano su limiti di parole doppie).
+		Vedi [link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei]
+		per maggiori informazioni.
+		</p>
+
+		<h2>Metodi</h2>
+
+    <p>
+			Vedi la classe base [page:Texture Texture] per i metodi comuni.
+    </p>
+
+		<h2>Source</h2>
+
+               <p>
+                       [link:https://github.com/mrdoob/three.js/blob/master/src/textures/DataCubeTexture.js src/textures/DataCubeTexture.js]
+               </p>
+	</body>
+</html>

--- a/docs/api/zh/textures/DataCubeTexture.html
+++ b/docs/api/zh/textures/DataCubeTexture.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="zh">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:Texture] &rarr;
+
+		<h1>[name]</h1>
+
+                <p class="desc">从原始数据创建一个立方体纹理。数据数组按 <code>+x</code>、<code>-x</code>、<code>+y</code>、<code>-y</code>、<code>+z</code>、<code>-z</code> 的顺序依次包含六个面的像素信息。</p>
+
+
+		<h2>构造函数</h2>
+
+		<h3>[name]( data, width, height, format, type, mapping, wrapS, wrapT, magFilter, minFilter, anisotropy, colorSpace )</h3>
+		<p>
+                        data 参数必须是一个 [link:https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView ArrayBufferView] 。
+                        数组长度应为 <code>width * height * 6 * n</code>，其中 <code>n</code> 是通道数量。
+                        其他参数对应于继承自 [page:Texture] 的属性，其中 magFilter 与 minFilter 默认为 THREE.NearestFilter。
+		</p>
+		<p>
+			数据的解释取决于type与format：
+			If the type is THREE.UnsignedByteType, a Uint8Array will be useful for addressing the texel data.
+			If the format is THREE.RGBAFormat, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity).<br />
+
+			For the packed types, THREE.UnsignedShort4444Type and THREE.UnsignedShort5551Type all color components of one texel can be addressed as bitfields within an integer element of a Uint16Array.<br />
+
+			In order to use the types THREE.FloatType and THREE.HalfFloatType, the WebGL implementation must support the respective extensions OES_texture_float and OES_texture_half_float. In order to use THREE.LinearFilter for component-wise, bilinear interpolation of the texels based on these types, the WebGL extensions OES_texture_float_linear or OES_texture_half_float_linear must also be present.
+		</p>
+
+		<h2>代码示例</h2>
+
+		<code>
+		// create a buffer with color data
+
+                const width = 256;
+                const height = 256;
+
+                const size = width * height;
+                const data = new Uint8Array( 4 * size * 6 );
+
+                for ( let i = 0; i < 6 * size; i ++ ) {
+
+                        const stride = i * 4;
+
+                        data[ stride ] = 255;
+                        data[ stride + 1 ] = 0;
+                        data[ stride + 2 ] = 0;
+                        data[ stride + 3 ] = 255;
+
+                }
+
+                // 使用该 buffer 创建 [name]
+
+                const texture = new THREE.DataCubeTexture( data, width, height );
+                texture.needsUpdate = true;
+		</code>
+
+		<h2>属性</h2>
+
+		<p>
+		See the base [page:Texture Texture] class for common properties.
+		</p>
+
+		<h3>[property:Boolean flipY]</h3>
+		<p>
+		If set to *true*, the texture is flipped along the vertical axis when uploaded to the GPU. Default is *false*.
+		</p>
+
+		<h3>[property:Boolean generateMipmaps]</h3>
+		<p>
+		Whether to generate mipmaps (if possible) for a texture. False by default.
+		</p>
+
+		<h3>[property:Object image]</h3>
+		<p>
+		Overridden with a record type holding data, width and height.
+		</p>
+
+                <h3>[property:Boolean isDataCubeTexture]</h3>
+                <p>
+                        只读属性，用于检查给定对象是否为[name]类型。
+                </p>
+
+		<h3>[property:number unpackAlignment]</h3>
+		<p>
+		1 by default. Specifies the alignment requirements for the start of each pixel row in memory.
+		The allowable values are 1 (byte-alignment), 2 (rows aligned to even-numbered bytes),
+		4 (word-alignment), and 8 (rows start on double-word boundaries).
+		See [link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei]
+		for more information.
+		</p>
+
+		<h2>方法</h2>
+
+		<p>
+		See the base [page:Texture Texture] class for common methods.
+		</p>
+
+		<h2>源码</h2>
+
+                <p>
+                        [link:https://github.com/mrdoob/three.js/blob/master/src/textures/DataCubeTexture.js src/textures/DataCubeTexture.js]
+                </p>
+	</body>
+</html>

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -20,12 +20,18 @@
  			other hardware-specific formats, this loader does not yet parse them.
 		</p>
 
-		<p>
-			This loader parses the KTX 2.0 container and transcodes to a supported GPU compressed
-			texture format. The required WASM transcoder and JS wrapper are available from the
-			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
-			directory.
-		</p>
+                <p>
+                        This loader parses the KTX 2.0 container and transcodes to a supported GPU compressed
+                        texture format. The required WASM transcoder and JS wrapper are available from the
+                        [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis]
+                        directory.
+                </p>
+
+                <p>
+                        In addition to compressed textures, uncompressed <code>u8</code>, <code>f16</code> and <code>f32</code>
+                        KTX2 files load as <code>DataTexture</code>, <code>DataArrayTexture</code>, or <code>DataCubeTexture</code>
+                        depending on the container type.
+                </p>
 
 		<h2>Import</h2>
 

--- a/docs/examples/zh/loaders/KTX2Loader.html
+++ b/docs/examples/zh/loaders/KTX2Loader.html
@@ -20,10 +20,15 @@
 		纹理，可以快速转码为多种 GPU 纹理压缩格式。虽然 KTX 2.0 还允许其他特定于硬件的格式，但此加载程序尚未解析它们。
 	</p>
 
-	<p>
-		该加载程序解析 KTX 2.0 容器并将其转码为受支持的 GPU 压缩纹理格式。所需的 WASM 转码器和 JS 包装器可从
-		[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis] 目录中获取。
-	</p>
+        <p>
+                该加载程序解析 KTX 2.0 容器并将其转码为受支持的 GPU 压缩纹理格式。所需的 WASM 转码器和 JS 包装器可从
+                [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/basis examples/jsm/libs/basis] 目录中获取。
+        </p>
+
+        <p>
+                除了压缩纹理外，未压缩的 <code>u8</code>、<code>f16</code> 和 <code>f32</code> KTX2 文件也被支持，
+                根据容器类型分别加载为 <code>DataTexture</code>、<code>DataArrayTexture</code> 或 <code>DataCubeTexture</code>。
+        </p>
 
 	<h2>导入</h2>
 

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -84,7 +84,8 @@
 
 			import * as THREE from 'three';
 
-			import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+                        import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+                        import { TextureHelper } from 'three/addons/helpers/TextureHelper.js';
 
 			let canvas, renderer;
 
@@ -118,17 +119,32 @@
 					]
 				},
 
-				{
-					title: 'Universal',
-					description: 'Basis Universal textures are specialized intermediate formats supporting fast'
-						+ ' runtime transcoding into other GPU texture compression formats. After transcoding,'
-						+ ' universal textures can be used on any device at reduced memory cost.',
-					textures: [
-						{ path: '2d_etc1s.ktx2' },
-						{ path: '2d_uastc.ktx2' },
-					]
-				},
-			]
+                                {
+                                        title: 'Universal',
+                                        description: 'Basis Universal textures are specialized intermediate formats supporting fast'
+                                                + ' runtime transcoding into other GPU texture compression formats. After transcoding,'
+                                                + ' universal textures can be used on any device at reduced memory cost.',
+                                        textures: [
+                                                { path: '2d_etc1s.ktx2' },
+                                                { path: '2d_uastc.ktx2' },
+                                        ]
+                                },
+                                {
+                                        title: 'Array',
+                                        description: 'KTX2 array textures load as DataArrayTexture or CompressedArrayTexture.',
+                                        textures: [
+                                                { path: 'arraytex_7.ktx2' },
+                                                { path: 'arraytex_7_mipmap.ktx2' }
+                                        ]
+                                },
+                                {
+                                        title: 'Cube',
+                                        description: 'KTX2 cube textures load as DataCubeTexture or CompressedCubeTexture.',
+                                        textures: [
+                                                { path: 'cubemap_6x6.ktx2' }
+                                        ]
+                                },
+                        ]
 
 			init();
 
@@ -187,13 +203,18 @@
 
 						try {
 
-							const texture = await loader.loadAsync( supported === false ? 'fail_load.ktx2' : path );
-							const mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial({ map: texture }) );
+                                                        const texture = await loader.loadAsync( supported === false ? 'fail_load.ktx2' : path );
+                                                        let mesh;
+                                                        if ( texture.isCubeTexture || texture.isCompressedCubeTexture || texture.isDataArrayTexture || texture.isCompressedArrayTexture ) {
+                                                                mesh = new TextureHelper( texture );
+                                                        } else {
+                                                                mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial( { map: texture } ) );
+                                                        }
 
-							labelElement.innerText += '\ncolorSpace: ' + texture.colorSpace;
+                                                        labelElement.innerText += '\ncolorSpace: ' + texture.colorSpace;
 
-							scene.add( mesh );
-							scenes.push( scene );
+                                                        scene.add( mesh );
+                                                        scenes.push( scene );
 
 						} catch (e) {
 


### PR DESCRIPTION
## Summary
- document `DataCubeTexture` in English, Italian, and Chinese
- mention array and cube texture support in `KTX2Loader` docs
- use `TextureHelper` for array and cube textures in KTX2 loader example

## Testing
- `npm run test-unit`

------
https://chatgpt.com/codex/tasks/task_e_68620500aca4832386c72f19c8233797